### PR TITLE
editsnipe and reactionsnipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,9 @@ dist
 # TernJS port file
 .tern-port
 
+# IDE config
+.idea/
+
+# other
+.DS_Store
 config.json

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Node.js 16.6.0 or newer is required.
 
 1. Run:
 
-```
+```bash
 $ git clone https://github.com/DankMemer/sniper.git
 $ cd ./sniper
 ```
 
 2. Create config.json:
 
-```
+```json
 {
 	"token": "<Your bot's token>",
 	"application_id": "<Your application's id>"
@@ -26,16 +26,16 @@ $ cd ./sniper
 
 3. Run:
 
-```
+```bash
 $ npm i
 $ npm run register [guild id]
 $ npm run bot
 ```
 
 Note:
-Without specifying [guild id], snipe command will available on all your app's guilds. It will fan out slowly across all guilds, and will be guaranteed to be updated in an hour (due to Discord's cache).
+Without specifying [guild id], snipe command will available on all of your app's guilds. It will fan out slowly across all guilds, and will be guaranteed to be updated in an hour (due to Discord's cache).
 
-With [guild id] it will be available only within the guild specified . It will update instantly.
+With [guild id] it will be available only within the guild specified. It will update instantly.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"main": "src/index.js",
 	"scripts": {
 		"register": "node scripts/register.js",
-		"bot": "node src/index.js"
+		"bot": "node src/index.js",
+		"prettier": "prettier --write \"**/*.js\""
 	},
 	"repository": {
 		"type": "git",

--- a/scripts/register.js
+++ b/scripts/register.js
@@ -9,6 +9,36 @@ const commands = [
 	{
 		name: "snipe",
 		description: "Shows the last deleted message from a specified channel!",
+		options: [
+			{
+				type: 7, // text channel
+				name: "channel",
+				description: "The channel to snipe",
+			},
+		],
+	},
+	{
+		name: "editsnipe",
+		description: "Shows the last edited message from a specified channel!",
+		options: [
+			{
+				type: 7, // text channel
+				name: "channel",
+				description: "The channel to snipe",
+			},
+		],
+	},
+	{
+		name: "reactionsnipe",
+		description:
+			"Shows the last removed reaction from a specified channel!",
+		options: [
+			{
+				type: 7, // text channel
+				name: "channel",
+				description: "The channel to snipe",
+			},
+		],
 	},
 ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,67 @@
 const { Client, Intents, MessageEmbed } = require("discord.js");
 const client = new Client({
-	intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES],
+	intents: [
+		Intents.FLAGS.GUILDS,
+		Intents.FLAGS.GUILD_MESSAGES,
+		Intents.FLAGS.GUILD_MESSAGE_REACTIONS,
+	],
+	partials: ["MESSAGE", "REACTION", "USER"],
 });
 const { token } = require("../config.json");
 
 const snipes = {};
+const editSnipes = {};
+const reactionSnipes = {};
+
+const formatEmoji = (emoji) => {
+	return !emoji.id || emoji.available
+		? emoji.toString() // bot has access or unicode emoji
+		: `[:${emoji.name}:](${emoji.url})`; // bot cannot use the emoji
+};
 
 client.on("ready", () => {
 	console.log(`[sniper] :: Logged in as ${client.user.tag}.`);
 });
 
 client.on("messageDelete", async (message) => {
-	snipes[message.guild.id] = {
+	if (message.partial) return; // content is null
+
+	snipes[message.channel.id] = {
 		author: message.author,
 		content: message.content,
 		createdAt: message.createdTimestamp,
 	};
 });
 
+client.on("messageUpdate", async (oldMessage, newMessage) => {
+	if (oldMessage.partial) return; // content is null
+
+	editSnipes[oldMessage.channel.id] = {
+		author: oldMessage.author,
+		content: oldMessage.content,
+		createdAt: newMessage.editedTimestamp,
+	};
+});
+
+client.on("messageReactionRemove", async (reaction, user) => {
+	if (reaction.partial) reaction = await reaction.fetch();
+
+	reactionSnipes[reaction.message.channel.id] = {
+		user: user,
+		emoji: reaction.emoji,
+		messageURL: reaction.message.url,
+		createdAt: Date.now(),
+	};
+});
+
 client.on("interactionCreate", async (interaction) => {
-	if (interaction.isCommand() && interaction.commandName === "snipe") {
-		const snipe = snipes[interaction.guildId];
+	if (!interaction.isCommand()) return;
+
+	const channel =
+		interaction.options.getChannel("channel") || interaction.channel;
+
+	if (interaction.commandName === "snipe") {
+		const snipe = snipes[channel.id];
 
 		await interaction.reply(
 			snipe
@@ -29,6 +70,43 @@ client.on("interactionCreate", async (interaction) => {
 							new MessageEmbed()
 								.setDescription(snipe.content)
 								.setAuthor(snipe.author.tag)
+								.setFooter(`#${channel.name}`)
+								.setTimestamp(snipe.createdAt),
+						],
+				  }
+				: "There's nothing to snipe!"
+		);
+	} else if (interaction.commandName === "editsnipe") {
+		const snipe = editSnipes[channel.id];
+
+		await interaction.reply(
+			snipe
+				? {
+						embeds: [
+							new MessageEmbed()
+								.setDescription(snipe.content)
+								.setAuthor(snipe.author.tag)
+								.setFooter(`#${channel.name}`)
+								.setTimestamp(snipe.createdAt),
+						],
+				  }
+				: "There's nothing to snipe!"
+		);
+	} else if (interaction.commandName === "reactionsnipe") {
+		const snipe = reactionSnipes[channel.id];
+
+		await interaction.reply(
+			snipe
+				? {
+						embeds: [
+							new MessageEmbed()
+								.setDescription(
+									`reacted with ${formatEmoji(
+										snipe.emoji
+									)} on [this message](${snipe.messageURL})`
+								)
+								.setAuthor(snipe.user.tag)
+								.setFooter(`#${channel.name}`)
 								.setTimestamp(snipe.createdAt),
 						],
 				  }


### PR DESCRIPTION
**What this PR changes:**
- Adds an editsnipe and reactionsnipe command
- Make sniping per-channel and add a slash command option for channel
- Adds a prettier format script (``npm run``)

**Extra info:**
- [x] Code is linted
- [x] Changes have been tested