### PR TITLE
Changes some code in index.js so embed open and messages edited by bots are not sniped

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ client.on("messageDelete", async (message) => {
 });
 
 client.on("messageUpdate", async (oldMessage, newMessage) => {
-	if (oldMessage.partial) return; // content is null
+	if (oldMessage.partial  || oldMessage === newMessage || newMessage.author.bot === true) return; // content is null
 
 	editSnipes[oldMessage.channel.id] = {
 		author: oldMessage.author.tag,


### PR DESCRIPTION
Before, sending GIFs caused this bot to snipe the gifs url, as embed opening counts as an edit. by changing one line in index.js, I was able to mitigate that